### PR TITLE
Fix issue with refresh token being updated on login

### DIFF
--- a/backend/src/main/kotlin/com/jetbrains/life_science/auth/AuthTokens.kt
+++ b/backend/src/main/kotlin/com/jetbrains/life_science/auth/AuthTokens.kt
@@ -1,6 +1,6 @@
 package com.jetbrains.life_science.auth
 
 class AuthTokens(
-    val jwt: String,
-    val refreshToken: String
+    var jwt: String,
+    var refreshToken: String
 )


### PR DESCRIPTION
If the refresh token is updated on login, refresh tokens from other sessions become invalid and the user is forced to religion on all other devices