### PR TITLE
Edit category patches

### DIFF
--- a/frontend/src/components/common/Button/sendByUrlButton.js
+++ b/frontend/src/components/common/Button/sendByUrlButton.js
@@ -16,7 +16,7 @@ export class SendByUrlButton extends React.Component {
     render() {
         return (
             <div className="button_container">
-                <button className={this.props.message + "_container"} onClick={this.onSubmit}>
+                <button className={this.props.message + "_button_container"} onClick={this.onSubmit}>
                     {this.props.message}
                 </button>
             </div>

--- a/frontend/src/components/common/Button/sendByUrlButton.js
+++ b/frontend/src/components/common/Button/sendByUrlButton.js
@@ -1,0 +1,32 @@
+import React from "react";
+import PropTypes from "prop-types";
+import {withRouter} from "react-router";
+
+export class SendByUrlButton extends React.Component {
+    constructor(props) {
+        super(props);
+        this.onSubmit = this.onSubmit.bind(this);
+    }
+
+
+    onSubmit() {
+        this.props.history.push(this.props.url);
+    }
+
+    render() {
+        return (
+            <div className="button_container">
+                <button className={this.props.message + "_container"} onClick={this.onSubmit}>
+                    {this.props.message}
+                </button>
+            </div>
+        )
+    }
+}
+
+SendByUrlButton.propType = {
+    message: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired,
+}
+
+export default withRouter(SendByUrlButton);

--- a/frontend/src/components/main/Categories/EditCategory/Parts/categoryForm.js
+++ b/frontend/src/components/main/Categories/EditCategory/Parts/categoryForm.js
@@ -1,7 +1,7 @@
 import React from "react";
 import {Button, Form} from "react-bootstrap";
 
-const CategoryForm = ({onSubmit, data, message, btnMessage, canChgParentId, error}) => {
+const CategoryForm = ({onSubmit, data, message, btnMessage}) => {
     return (
         <div className="addCategory_container">
             <div className="form_container">
@@ -13,14 +13,9 @@ const CategoryForm = ({onSubmit, data, message, btnMessage, canChgParentId, erro
                         <Form.Label>Category Name</Form.Label>
                         <Form.Control size="lg" type="text" defaultValue={data.name} />
                     </Form.Group>
-                    <Form.Group controlId="parentId">
-                        <Form.Label>Parent category id</Form.Label>
-                        <Form.Control readOnly={!canChgParentId} size="lg" defaultValue={data.parentId} />
-                        {error && error.message}
-                    </Form.Group>
                     <Form.Group controlId="order">
-                        <Form.Label>Order</Form.Label>
-                        <Form.Control size="lg" type="range" min={0} max={20} defaultValue={data.order} />
+                        <Form.Label>Showing position</Form.Label>
+                        <Form.Control size="lg" type="range" min={0} max={10} defaultValue={data.order} />
                     </Form.Group>
                     <Button variant="primary" type="submit" block>
                         {btnMessage}

--- a/frontend/src/components/main/Categories/EditCategory/Parts/editCategory.js
+++ b/frontend/src/components/main/Categories/EditCategory/Parts/editCategory.js
@@ -38,16 +38,11 @@ class EditCategory extends React.Component {
         event.preventDefault();
         const data = {
             name: event.target.elements.name.value,
-            parentId: event.target.elements.parentId.value,
+            parentId: this.props.category.parentId,
             order: event.target.elements.order.value
         }
-        if (data.parentId > 0) {
-            this.props.putCategoryThunk(this.props.match.params.id, data)
-            this.props.history.push(`/categories/${this.props.match.params.id}`);
-            return
-        }
-        const error = {message: <span className="error">Parent id must be more than 0</span>};
-        this.setState({error: error})
+        this.props.clearCategory();
+        this.props.history.push(`/categories/${this.props.match.params.id}`);
     }
 
     render() {

--- a/frontend/src/components/main/Categories/EditCategory/Parts/editCategory.js
+++ b/frontend/src/components/main/Categories/EditCategory/Parts/editCategory.js
@@ -6,6 +6,7 @@ import Preloader from "../../../../common/Preloader/preloader";
 import {clearCategory, getCategoryThunk} from "../../../../../redux/actions/category-actions";
 import {connect} from "react-redux";
 import "../editCategory.css";
+import SendByUrlButton from "../../../../common/Button/sendByUrlButton";
 
 class EditCategory extends React.Component {
     constructor(props) {
@@ -41,6 +42,7 @@ class EditCategory extends React.Component {
             parentId: this.props.category.parentId,
             order: event.target.elements.order.value
         }
+        this.props.putCategoryThunk(this.props.match.params.id, data);
         this.props.clearCategory();
         this.props.history.push(`/categories/${this.props.match.params.id}`);
     }
@@ -61,10 +63,15 @@ class EditCategory extends React.Component {
         }
 
         return (
-            <CategoryForm onSubmit={this.handleSubmit}
-                          message={"Edit Category"}
-                          data={data} btnMessage={"Edit"}
-                          canChgParentId={true} error={this.state?.error}/>
+            <div>
+                <div className="buttons_container">
+                    <SendByUrlButton message="Previous" url={"/category/" + this.props.match.params.id} {...this.props} />
+                </div>
+                <CategoryForm onSubmit={this.handleSubmit}
+                              message={"Edit Category"}
+                              data={data} btnMessage={"Edit"}
+                              canChgParentId={true} error={this.state?.error}/>
+            </div>
         )
     }
 }

--- a/frontend/src/components/main/Categories/EditCategory/Parts/newCategory.js
+++ b/frontend/src/components/main/Categories/EditCategory/Parts/newCategory.js
@@ -17,10 +17,11 @@ class NewCategory extends React.Component {
         event.preventDefault();
         const data = {
             name: event.target.elements.name.value,
-            parentId: event.target.elements.parentId.value,
+            parentId: this.props.match.params.parentId,
             order: event.target.elements.order.value
         }
         this.props.postCategoryThunk(data)
+        this.props.clearCategory();
         this.props.history.push(`/categories/${this.props.match.params.parentId}`);
     }
 

--- a/frontend/src/components/main/Categories/EditCategory/Parts/newCategory.js
+++ b/frontend/src/components/main/Categories/EditCategory/Parts/newCategory.js
@@ -6,6 +6,7 @@ import {
 import {ROLES} from "../../../../../constants";
 import "../editCategory.css";
 import CategoryForm from "./categoryForm";
+import SendByUrlButton from "../../../../common/Button/sendByUrlButton";
 
 class NewCategory extends React.Component {
     constructor(props) {
@@ -36,10 +37,15 @@ class NewCategory extends React.Component {
         }
 
         return (
-            <CategoryForm onSubmit={this.handleSubmit}
-                          message={"Add Category"}
-                          data={data} btnMessage={"Save"}
-                          canChgParentId={false} />
+            <div>
+                <div className="buttons_container">
+                    <SendByUrlButton message="Previous" url={"/category/" + this.props.match.params.parentId} {...this.props} />
+                </div>
+                <CategoryForm onSubmit={this.handleSubmit}
+                              message={"Add Category"}
+                              data={data} btnMessage={"Save"}
+                              canChgParentId={false} />
+            </div>
         )
     }
 }

--- a/frontend/src/components/main/Categories/EditCategory/editCategoryContainer.js
+++ b/frontend/src/components/main/Categories/EditCategory/editCategoryContainer.js
@@ -1,6 +1,7 @@
 import React from "react";
 import {withRouter} from "react-router";
 import {
+    clearCategory,
     deleteCategoryThunk,
     getCategoryThunk,
     postCategoryThunk,
@@ -54,4 +55,4 @@ let mapStateToProps = (state) => {
 
 let WithDataContainerComponent = withRouter(EditCategoryContainer);
 
-export default connect(mapStateToProps, {postCategoryThunk, putCategoryThunk, deleteCategoryThunk, getAuthorizedUserThunk, getCategoryThunk})(WithDataContainerComponent);
+export default connect(mapStateToProps, {postCategoryThunk, putCategoryThunk, deleteCategoryThunk, getAuthorizedUserThunk, getCategoryThunk, clearCategory})(WithDataContainerComponent);

--- a/frontend/src/components/main/Categories/EditCategory/shortCategory.js
+++ b/frontend/src/components/main/Categories/EditCategory/shortCategory.js
@@ -3,7 +3,11 @@ import {ROLES} from "../../../../constants";
 import {withRouter} from "react-router";
 import Preloader from "../../../common/Preloader/preloader";
 import {connect} from "react-redux";
-import {clearCategory, deleteCategoryThunk, getCategoryThunk} from "../../../../redux/actions/category-actions";
+import {
+    clearCategory,
+    deleteCategoryThunk,
+    getCategoryThunk
+} from "../../../../redux/actions/category-actions";
 import {
     Button,
     Card
@@ -41,7 +45,6 @@ class ShortCategory extends React.Component {
     onDelete(event) {
         event.preventDefault();
         this.props.deleteCategoryThunk(this.props.match.params.id);
-        this.props.clearCategory();
         this.props.history.push(`/categories/${this.props.category.parentId}`)
     }
 

--- a/frontend/src/components/main/Categories/EditCategory/shortCategory.js
+++ b/frontend/src/components/main/Categories/EditCategory/shortCategory.js
@@ -75,10 +75,22 @@ class ShortCategory extends React.Component {
         }
 
         const deleteButton = () => {
-            if (this.props.category.articles.length === 0) {
+            if (this.props.category.articles.length === 0
+                && this.props.category.subcategories.length === 0
+                && this.props.category.id !== 1) {
                 return(
                     <Button variant="danger" size="lg" block onClick={this.onDelete}>
                         Delete Category
+                    </Button>
+                );
+            }
+        }
+
+        const editButton = () => {
+            if (this.props.category.id !== 1) {
+                return(
+                    <Button variant="secondary" size="lg" block onClick={this.onEdit}>
+                        Edit Category
                     </Button>
                 );
             }
@@ -91,9 +103,7 @@ class ShortCategory extends React.Component {
 
             return(
                 <div className="buttons">
-                    <Button variant="secondary" size="lg" block onClick={this.onEdit}>
-                        Edit Category
-                    </Button>
+                    {editButton()}
                     {addButton()}
                     {deleteButton()}
                 </div>

--- a/frontend/src/components/main/Categories/EditCategory/shortCategory.js
+++ b/frontend/src/components/main/Categories/EditCategory/shortCategory.js
@@ -126,8 +126,7 @@ class ShortCategory extends React.Component {
                         <Card.Body>
                             <Card.Title>{data.name}</Card.Title>
                             <Card.Text>
-                                ParentId of category: {data.parentId} <br/>
-                                Category has order number: {data.order}
+                                Category has showing priority: {data.order}
                             </Card.Text>
                             {showingButtons()}
                         </Card.Body>

--- a/frontend/src/components/main/Categories/EditCategory/shortCategory.js
+++ b/frontend/src/components/main/Categories/EditCategory/shortCategory.js
@@ -13,6 +13,7 @@ import {
     Card
 } from "react-bootstrap";
 import "./editCategory.css"
+import SendByUrlButton from "../../../common/Button/sendByUrlButton";
 
 class ShortCategory extends React.Component {
     constructor(props) {
@@ -106,17 +107,22 @@ class ShortCategory extends React.Component {
         }
 
         return (
-            <div className="short_category_container">
-                <Card>
-                    <Card.Body>
-                        <Card.Title>{data.name}</Card.Title>
-                        <Card.Text>
-                            ParentId of category: {data.parentId} <br/>
-                            Category has order number: {data.order}
-                        </Card.Text>
-                        {showingButtons()}
-                    </Card.Body>
-                </Card>
+            <div>
+                <div className="buttons_container">
+                    <SendByUrlButton message="Previous" url={"/categories/" + this.props.match.params.id} {...this.props} />
+                </div>
+                <div className="short_category_container">
+                    <Card>
+                        <Card.Body>
+                            <Card.Title>{data.name}</Card.Title>
+                            <Card.Text>
+                                ParentId of category: {data.parentId} <br/>
+                                Category has order number: {data.order}
+                            </Card.Text>
+                            {showingButtons()}
+                        </Card.Body>
+                    </Card>
+                </div>
             </div>
         )
     }

--- a/frontend/src/components/main/Categories/categoriesContainer.js
+++ b/frontend/src/components/main/Categories/categoriesContainer.js
@@ -15,7 +15,10 @@ class CategoriesContainer extends React.Component {
     }
 
     componentDidUpdate(prevProps, prevState, snapshot) {
-        if (this.props.match.params.categoryId !== prevProps.match.params.categoryId ) {
+        if (this.props.match.params.categoryId !== prevProps.match.params.categoryId ||
+            this.props.category?.id !== this.props.match.params.categoryId ||
+            this.props.category?.articles.length !== prevProps.category?.articles.length ||
+            this.props.category?.subcategories.length !== prevProps.category?.subcategories.length) {
             this.refreshCategories();
         }
     }

--- a/frontend/src/components/main/Categories/categoriesContainer.js
+++ b/frontend/src/components/main/Categories/categoriesContainer.js
@@ -14,13 +14,18 @@ class CategoriesContainer extends React.Component {
         this.props.getCategoryThunk(categoryId);
     }
 
-    componentDidUpdate(prevProps, prevState, snapshot) {
-        if (this.props.match.params.categoryId !== prevProps.match.params.categoryId ||
-            this.props.category?.id !== this.props.match.params.categoryId ||
-            this.props.category?.articles.length !== prevProps.category?.articles.length ||
-            this.props.category?.subcategories.length !== prevProps.category?.subcategories.length) {
-            this.refreshCategories();
+    shouldComponentUpdate(nextProps, nextState, nextContext) {
+        if (this.props.match.params.categoryId !== nextProps.match.params.categoryId ||
+            (this.props.match.params?.categoryId && this.props.match.params?.categoryId != this.props.category?.id) || //Не менять на !== (все летит)
+            this.props.category?.articles.length !== nextProps.category?.articles.length ||
+            this.props.category?.subcategories.length !== nextProps.category?.subcategories.length) {
+            return true;
         }
+        return false;
+    }
+
+    componentDidUpdate(prevProps, prevState, snapshot) {
+        this.refreshCategories();
     }
 
     componentWillUnmount() {

--- a/frontend/src/redux/actions/category-actions.js
+++ b/frontend/src/redux/actions/category-actions.js
@@ -22,10 +22,12 @@ export const clearCategory = () => {
 
 export const getCategoryThunk = (id) => async (dispatch) => {
     const response = await categoryApi.getCategory(id);
+
     if (response.status !== 200) {
         dispatch(getError(ERROR, response))
         return;
     }
+
     dispatch(getCategory(response.data))
 }
 
@@ -56,7 +58,7 @@ export const deleteCategoryThunk = (id) => async (dispatch) => {
     const response = await categoryApi.deleteCategory(id);
 
     if (response.status !== 200) {
-        dispatch(getError(ERROR, response))
+        dispatch(getError(ERROR, response));
     }
 }
 

--- a/frontend/src/redux/actions/category-actions.js
+++ b/frontend/src/redux/actions/category-actions.js
@@ -21,7 +21,6 @@ export const clearCategory = () => {
 }
 
 export const getCategoryThunk = (id) => async (dispatch) => {
-    dispatch(clearCategory())
     const response = await categoryApi.getCategory(id);
 
     if (response.status !== 200) {
@@ -39,15 +38,11 @@ export const getCategoryThunk = (id) => async (dispatch) => {
  * @returns {(function(*): Promise<void>)|*}
  */
 export const postCategoryThunk = (data) => async (dispatch) => {
-    dispatch(clearCategory())
     const response = await categoryApi.postCategory(data);
 
     if (response.status !== 200) {
         dispatch(getError(ERROR, response))
-        return;
     }
-
-    dispatch(getCategory(response.data))
 }
 
 /**
@@ -57,7 +52,6 @@ export const postCategoryThunk = (data) => async (dispatch) => {
  * @returns {(function(*): Promise<void>)|*}
  */
 export const deleteCategoryThunk = (id) => async (dispatch) => {
-    dispatch(clearCategory())
     const response = await categoryApi.deleteCategory(id);
 
     if (response.status !== 200) {

--- a/frontend/src/redux/actions/category-actions.js
+++ b/frontend/src/redux/actions/category-actions.js
@@ -21,6 +21,7 @@ export const clearCategory = () => {
 }
 
 export const getCategoryThunk = (id) => async (dispatch) => {
+    dispatch(clearCategory())
     const response = await categoryApi.getCategory(id);
 
     if (response.status !== 200) {
@@ -38,6 +39,7 @@ export const getCategoryThunk = (id) => async (dispatch) => {
  * @returns {(function(*): Promise<void>)|*}
  */
 export const postCategoryThunk = (data) => async (dispatch) => {
+    dispatch(clearCategory())
     const response = await categoryApi.postCategory(data);
 
     if (response.status !== 200) {
@@ -55,6 +57,7 @@ export const postCategoryThunk = (data) => async (dispatch) => {
  * @returns {(function(*): Promise<void>)|*}
  */
 export const deleteCategoryThunk = (id) => async (dispatch) => {
+    dispatch(clearCategory())
     const response = await categoryApi.deleteCategory(id);
 
     if (response.status !== 200) {

--- a/frontend/src/redux/category-reducer.js
+++ b/frontend/src/redux/category-reducer.js
@@ -30,7 +30,8 @@ const categoryReducer = (state = initialState, action) => {
         case CLEAR_CATEGORY:
             return {
                 ...state,
-                isReceived: false
+                isReceived: false,
+                category: null,
             }
         default:
             return state;


### PR DESCRIPTION
Add button now shows, only if category hasn't articles.
Delete button shows, only if category is empty.
Edit button shows for every one, except root category.
Added reverse buttons while working with category.
Some bugs fixed.
P.S. don't remove != in category container, unless you do this, category page will update every millisecond.