### PR TITLE
#LS-94

### DIFF
--- a/src/main/kotlin/com/jetbrains/life_science/approach/factory/DraftApproachFactory.kt
+++ b/src/main/kotlin/com/jetbrains/life_science/approach/factory/DraftApproachFactory.kt
@@ -2,6 +2,7 @@ package com.jetbrains.life_science.approach.factory
 
 import com.jetbrains.life_science.approach.entity.DraftApproach
 import com.jetbrains.life_science.approach.service.DraftApproachInfo
+import com.jetbrains.life_science.util.UTCZone
 import org.springframework.stereotype.Component
 import java.time.LocalDateTime
 
@@ -16,7 +17,7 @@ class DraftApproachFactory {
             owner = info.owner,
             participants = mutableListOf(info.owner),
             sections = mutableListOf(),
-            creationDate = LocalDateTime.now()
+            creationDate = LocalDateTime.now(UTCZone)
         )
     }
 

--- a/src/main/kotlin/com/jetbrains/life_science/auth/refresh/factory/RefreshTokenFactoryImpl.kt
+++ b/src/main/kotlin/com/jetbrains/life_science/auth/refresh/factory/RefreshTokenFactoryImpl.kt
@@ -2,6 +2,7 @@ package com.jetbrains.life_science.auth.refresh.factory
 
 import com.jetbrains.life_science.auth.refresh.entity.RefreshToken
 import com.jetbrains.life_science.user.credentials.entity.Credentials
+import com.jetbrains.life_science.util.UTCZone
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import java.security.MessageDigest
@@ -28,7 +29,7 @@ class RefreshTokenFactoryImpl : RefreshTokenFactory {
     }
 
     private fun generateExpirationTime(): LocalDateTime {
-        return LocalDateTime.now().plusSeconds(refreshExpirationSeconds.toLong())
+        return LocalDateTime.now(UTCZone).plusSeconds(refreshExpirationSeconds.toLong())
     }
 
     private fun generateRefreshToken(username: String): String {

--- a/src/main/kotlin/com/jetbrains/life_science/auth/refresh/service/RefreshTokenServiceImpl.kt
+++ b/src/main/kotlin/com/jetbrains/life_science/auth/refresh/service/RefreshTokenServiceImpl.kt
@@ -6,6 +6,7 @@ import com.jetbrains.life_science.auth.refresh.repository.RefreshTokenRepository
 import com.jetbrains.life_science.exception.auth.ExpiredRefreshTokenException
 import com.jetbrains.life_science.exception.auth.InvalidRefreshTokenException
 import com.jetbrains.life_science.user.credentials.entity.Credentials
+import com.jetbrains.life_science.util.UTCZone
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
@@ -24,7 +25,7 @@ class RefreshTokenServiceImpl(
 
     override fun getCredentialsByRefreshToken(refreshTokenCode: RefreshTokenCode): Credentials {
         val refreshToken = repository.findByCode(refreshTokenCode.code) ?: throw InvalidRefreshTokenException()
-        if (refreshToken.expirationDateTime < LocalDateTime.now()) {
+        if (refreshToken.expirationDateTime < LocalDateTime.now(UTCZone)) {
             throw ExpiredRefreshTokenException()
         }
         return refreshToken.credentials

--- a/src/main/kotlin/com/jetbrains/life_science/category/factory/CategoryFactory.kt
+++ b/src/main/kotlin/com/jetbrains/life_science/category/factory/CategoryFactory.kt
@@ -2,6 +2,7 @@ package com.jetbrains.life_science.category.factory
 
 import com.jetbrains.life_science.category.entity.Category
 import com.jetbrains.life_science.category.service.CategoryInfo
+import com.jetbrains.life_science.util.UTCZone
 import org.springframework.stereotype.Component
 import java.time.LocalDateTime
 
@@ -15,7 +16,7 @@ class CategoryFactory {
             subCategories = mutableListOf(),
             approaches = mutableListOf(),
             parents = parents,
-            creationDate = LocalDateTime.now(),
+            creationDate = LocalDateTime.now(UTCZone),
             aliases = info.aliases
         )
     }

--- a/src/main/kotlin/com/jetbrains/life_science/controller/approach/draft/DraftApproachController.kt
+++ b/src/main/kotlin/com/jetbrains/life_science/controller/approach/draft/DraftApproachController.kt
@@ -13,6 +13,7 @@ import com.jetbrains.life_science.review.request.service.PublishApproachRequestI
 import com.jetbrains.life_science.review.request.service.PublishApproachRequestService
 import com.jetbrains.life_science.user.credentials.entity.Credentials
 import com.jetbrains.life_science.user.credentials.service.CredentialsService
+import com.jetbrains.life_science.util.UTCZone
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 import java.time.LocalDateTime
@@ -96,6 +97,6 @@ class DraftApproachController(
         override val approach: DraftApproach
     ) : PublishApproachRequestInfo {
         override val id: Long = 0
-        override val date: LocalDateTime = LocalDateTime.now()
+        override val date: LocalDateTime = LocalDateTime.now(UTCZone)
     }
 }

--- a/src/test/kotlin/com/jetbrains/life_science/protocol/draft/service/DraftProtocolServiceTest.kt
+++ b/src/test/kotlin/com/jetbrains/life_science/protocol/draft/service/DraftProtocolServiceTest.kt
@@ -9,6 +9,7 @@ import com.jetbrains.life_science.protocol.service.DraftProtocolService
 import com.jetbrains.life_science.section.service.SectionService
 import com.jetbrains.life_science.user.credentials.entity.Credentials
 import com.jetbrains.life_science.user.credentials.service.CredentialsService
+import com.jetbrains.life_science.util.UTCZone
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -344,6 +345,6 @@ class DraftProtocolServiceTest {
             coAuthors = mutableListOf(),
             categories = mutableListOf(),
             protocols = mutableListOf(),
-            creationDate = LocalDateTime.now()
+            creationDate = LocalDateTime.now(UTCZone)
         )
 }

--- a/src/test/kotlin/com/jetbrains/life_science/review/request/service/PublishApproachRequestServiceTest.kt
+++ b/src/test/kotlin/com/jetbrains/life_science/review/request/service/PublishApproachRequestServiceTest.kt
@@ -10,6 +10,7 @@ import com.jetbrains.life_science.review.response.entity.Review
 import com.jetbrains.life_science.review.response.entity.ReviewResolution
 import com.jetbrains.life_science.user.credentials.entity.Credentials
 import com.jetbrains.life_science.user.credentials.service.CredentialsService
+import com.jetbrains.life_science.util.UTCZone
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -204,7 +205,10 @@ class PublishApproachRequestServiceTest {
         // Prepare data
         val publishApproachId = 239L
         val reviewer = credentialsService.getById(3L)
-        val review = createReview(3, LocalDateTime.now(), "third review", ReviewResolution.APPROVE, reviewer)
+        val review = createReview(
+            3, LocalDateTime.now(UTCZone),
+            "third review", ReviewResolution.APPROVE, reviewer
+        )
 
         // Action & Assert
         assertThrows<PublishApproachRequestNotFoundException> {
@@ -224,7 +228,7 @@ class PublishApproachRequestServiceTest {
             tags = mutableListOf(),
             sections = mutableListOf(),
             categories = mutableListOf(),
-            creationDate = LocalDateTime.now(),
+            creationDate = LocalDateTime.now(UTCZone),
             participants = mutableListOf(owner)
         )
 

--- a/src/test/kotlin/com/jetbrains/life_science/review/request/service/PublishProtocolRequestServiceTest.kt
+++ b/src/test/kotlin/com/jetbrains/life_science/review/request/service/PublishProtocolRequestServiceTest.kt
@@ -11,6 +11,7 @@ import com.jetbrains.life_science.review.response.entity.Review
 import com.jetbrains.life_science.review.response.entity.ReviewResolution
 import com.jetbrains.life_science.user.credentials.entity.Credentials
 import com.jetbrains.life_science.user.credentials.service.CredentialsService
+import com.jetbrains.life_science.util.UTCZone
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -209,7 +210,10 @@ class PublishProtocolRequestServiceTest {
         // Prepare data
         val publishProtocolId = 239L
         val reviewer = credentialsService.getById(3L)
-        val review = createReview(3, LocalDateTime.now(), "third review", ReviewResolution.APPROVE, reviewer)
+        val review = createReview(
+            3, LocalDateTime.now(UTCZone),
+            "third review", ReviewResolution.APPROVE, reviewer
+        )
 
         // Action & Assert
         assertThrows<PublishProtocolRequestNotFoundException> {

--- a/src/test/kotlin/com/jetbrains/life_science/review/response/service/maker/ReviewInfoMaker.kt
+++ b/src/test/kotlin/com/jetbrains/life_science/review/response/service/maker/ReviewInfoMaker.kt
@@ -3,6 +3,7 @@ package com.jetbrains.life_science.review.response.service.maker
 import com.jetbrains.life_science.review.response.entity.ReviewResolution
 import com.jetbrains.life_science.review.response.service.ReviewInfo
 import com.jetbrains.life_science.user.credentials.entity.Credentials
+import com.jetbrains.life_science.util.UTCZone
 import java.time.LocalDateTime
 
 fun makeReviewInfo(
@@ -12,7 +13,7 @@ fun makeReviewInfo(
     reviewer: Credentials
 ) = object : ReviewInfo {
     override val id = id
-    override val date = LocalDateTime.now()
+    override val date = LocalDateTime.now(UTCZone)
     override val comment = comment
     override val resolution = resolution
     override val reviewer = reviewer


### PR DESCRIPTION
При вызове LocalDateTime.now() теперь в аргументах явно передаётся часовой пояс, для избежания ошибок.